### PR TITLE
Can now query all events within X miles of geolocation via /api/event…

### DIFF
--- a/models/Event.js
+++ b/models/Event.js
@@ -7,7 +7,7 @@ const EventSchema = new mongoose.Schema({
   location: {
     type: {
       type: String,
-      default: "Point",
+      enum: ["Point"],
     },
     coordinates: {
       type: [Number], // lat, long


### PR DESCRIPTION
…s/near endpoint

Hit the endpoint /api/events/near with:

lng, lat, miles

all numbers, where lng is longitude, lat is latitude, and miles is some reasonable number (5 is a good baseline)

Closes #9 